### PR TITLE
Downgrade required ruby version to 2.2.6

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 2.2.7'
+  gem.required_ruby_version     = '>= 2.2.6'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')


### PR DESCRIPTION
## What / Why

We will be migrating to a containerized environment with an updated Ruby soon, but in the meantime, pin the latest release to 2.2.6 instead of 2.2.7 to get us through the Rails 5.1 upgrade.

## How was it tested?
Specs against Ruby 2.2.6

```
echo `ruby --version` && bundle exec rake
ruby 2.2.6p396 (2016-11-15 revision 56800) [x86_64-darwin16]
cp spec/internal/config/database.yml.sample spec/internal/config/database.yml
/Users/bill.thompson/.rvm/rubies/ruby-2.2.6/bin/ruby -I/Users/bill.thompson/.rvm/gems/ruby-2.2.6/gems/rspec-core-3.7.1/lib:/Users/bill.thompson/.rvm/gems/ruby-2.2.6/gems/rspec-support-3.7.0/lib /Users/bill.thompson/.rvm/gems/ruby-2.2.6/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*/\*_spec.rb
........................................................................*......................................................................................log writing failed. "\xE3" from ASCII-8BIT to UTF-8
........................................................................log writing failed. "\xE6" from ASCII-8BIT to UTF-8
.log writing failed. "\xD7" from ASCII-8BIT to UTF-8
.log writing failed. "\xE4" from ASCII-8BIT to UTF-8
.log writing failed. "\xD8" from ASCII-8BIT to UTF-8
.log writing failed. "\xE2" from ASCII-8BIT to UTF-8
....log writing failed. "\xD0" from ASCII-8BIT to UTF-8
....log writing failed. "\xD0" from ASCII-8BIT to UTF-8
.........................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Acts As Taggable On CachingWithArray #TODO
     # Not yet implemented
     # ./spec/acts_as_taggable_on/caching_spec.rb:121


Finished in 9.74 seconds (files took 1.14 seconds to load)
284 examples, 0 failures, 1 pending
```